### PR TITLE
Workaround for https://forum.getkirby.com/t/kirby3-janitor-a-panel-button-to-run-jobs-defined-in-php/23573/16

### DIFF
--- a/index.php
+++ b/index.php
@@ -45,11 +45,14 @@ Kirby::plugin('bnomei/janitor', [
 
                     // append model
                     if ($this->model() instanceof \Kirby\Cms\Page) {
-                        $command .= ' --page page://' . $uuid ?? $this->model()->id();
+                        $uuid = !empty($uuid) ? 'page://'. $uuid : null;
+                        $command .= ' --page ' . $uuid ?? $this->model()->id();
                     } elseif ($this->model() instanceof \Kirby\Cms\File) {
-                        $command .= ' --file file://' . $uuid ?? $this->model()->id();
+                        $uuid = !empty($uuid) ? 'file://'. $uuid : null;
+                        $command .= ' --file ' . $uuid ?? $this->model()->id();
                     } elseif ($this->model() instanceof \Kirby\Cms\User) {
-                        $command .= ' --user user://' . $uuid ?? $this->model()->id();
+                        $uuid = !empty($uuid) ? 'user://'. $uuid : null;
+                        $command .= ' --user ' . $uuid ?? $this->model()->id();
                     } elseif ($this->model() instanceof \Kirby\Cms\Site) {
                         $command .= ' --site'; // boolean argument
                     }

--- a/index.php
+++ b/index.php
@@ -41,15 +41,15 @@ Kirby::plugin('bnomei/janitor', [
                     $command = \Bnomei\Janitor::query($command, $this->model());
                     // append model
                     if ($this->model() instanceof \Kirby\Cms\Page) {
-                        $command .= ' --page ' . $this->model()->uuid()?->toString() ?? $this->model()->id();
+                        $command .= ' --page ' . $this->model()->content()->uuid()?->toString() ?? $this->model()->id();
                     } elseif ($this->model() instanceof \Kirby\Cms\File) {
-                        $command .= ' --file ' . $this->model()->uuid()?->toString() ?? $this->model()->id();
+                        $command .= ' --file ' . $this->model()->content()->uuid()?->toString() ?? $this->model()->id();
                     } elseif ($this->model() instanceof \Kirby\Cms\User) {
-                        $command .= ' --user ' . $this->model()->uuid()?->toString() ?? $this->model()->id();
+                        $command .= ' --user ' . $this->model()->content()->uuid()?->toString() ?? $this->model()->id();
                     } elseif ($this->model() instanceof \Kirby\Cms\Site) {
                         $command .= ' --site'; // boolean argument
                     }
-                    $command .= ' --model '. $this->model()->uuid()?->toString() ??
+                    $command .= ' --model '. $this->model()->content()->uuid()?->toString() ??
                         ($this->model() instanceof \Kirby\Cms\Site ? 'site://' : $this->model()->id());
 
                     $command .= ' --quiet'; // no STDOUT on frontend PHP

--- a/index.php
+++ b/index.php
@@ -39,14 +39,17 @@ Kirby::plugin('bnomei/janitor', [
                 'command' => function ($command = null) {
                     // resolve queries
                     $command = \Bnomei\Janitor::query($command, $this->model());
-                    $uuid = 'page://'.$this->model()->content()->uuid()?->toString();
+
+                    // Temporary fix for https://github.com/getkirby/kirby/issues/4955
+                    $uuid = $this->model()->content()->uuid()?->toString();
+
                     // append model
                     if ($this->model() instanceof \Kirby\Cms\Page) {
-                        $command .= ' --page ' . $uuid ?? $this->model()->id();
+                        $command .= ' --page page://' . $uuid ?? $this->model()->id();
                     } elseif ($this->model() instanceof \Kirby\Cms\File) {
-                        $command .= ' --file ' . $uuid ?? $this->model()->id();
+                        $command .= ' --file file://' . $uuid ?? $this->model()->id();
                     } elseif ($this->model() instanceof \Kirby\Cms\User) {
-                        $command .= ' --user ' . $uuid ?? $this->model()->id();
+                        $command .= ' --user user://' . $uuid ?? $this->model()->id();
                     } elseif ($this->model() instanceof \Kirby\Cms\Site) {
                         $command .= ' --site'; // boolean argument
                     }

--- a/index.php
+++ b/index.php
@@ -45,11 +45,14 @@ Kirby::plugin('bnomei/janitor', [
 
                     // append model
                     if ($this->model() instanceof \Kirby\Cms\Page) {
-                        $command .= ' --page page://' . $uuid ?? $this->model()->id();
+                        $uuid ??= 'page://'. $uuid;
+                        $command .= ' --page ' . $uuid ?? $this->model()->id();
                     } elseif ($this->model() instanceof \Kirby\Cms\File) {
-                        $command .= ' --file file://' . $uuid ?? $this->model()->id();
+                        $uuid ??= 'file://'. $uuid;
+                        $command .= ' --file ' . $uuid ?? $this->model()->id();
                     } elseif ($this->model() instanceof \Kirby\Cms\User) {
-                        $command .= ' --user user://' . $uuid ?? $this->model()->id();
+                        $uuid ??= 'user://'. $uuid;
+                        $command .= ' --user ' . $uuid ?? $this->model()->id();
                     } elseif ($this->model() instanceof \Kirby\Cms\Site) {
                         $command .= ' --site'; // boolean argument
                     }

--- a/index.php
+++ b/index.php
@@ -45,14 +45,11 @@ Kirby::plugin('bnomei/janitor', [
 
                     // append model
                     if ($this->model() instanceof \Kirby\Cms\Page) {
-                        $uuid ??= 'page://'. $uuid;
-                        $command .= ' --page ' . $uuid ?? $this->model()->id();
+                        $command .= ' --page page://' . $uuid ?? $this->model()->id();
                     } elseif ($this->model() instanceof \Kirby\Cms\File) {
-                        $uuid ??= 'file://'. $uuid;
-                        $command .= ' --file ' . $uuid ?? $this->model()->id();
+                        $command .= ' --file file://' . $uuid ?? $this->model()->id();
                     } elseif ($this->model() instanceof \Kirby\Cms\User) {
-                        $uuid ??= 'user://'. $uuid;
-                        $command .= ' --user ' . $uuid ?? $this->model()->id();
+                        $command .= ' --user user://' . $uuid ?? $this->model()->id();
                     } elseif ($this->model() instanceof \Kirby\Cms\Site) {
                         $command .= ' --site'; // boolean argument
                     }

--- a/index.php
+++ b/index.php
@@ -39,17 +39,18 @@ Kirby::plugin('bnomei/janitor', [
                 'command' => function ($command = null) {
                     // resolve queries
                     $command = \Bnomei\Janitor::query($command, $this->model());
+                    $uuid = 'page://'.$this->model()->content()->uuid()?->toString();
                     // append model
                     if ($this->model() instanceof \Kirby\Cms\Page) {
-                        $command .= ' --page ' . $this->model()->content()->uuid()?->toString() ?? $this->model()->id();
+                        $command .= ' --page ' . $uuid ?? $this->model()->id();
                     } elseif ($this->model() instanceof \Kirby\Cms\File) {
-                        $command .= ' --file ' . $this->model()->content()->uuid()?->toString() ?? $this->model()->id();
+                        $command .= ' --file ' . $uuid ?? $this->model()->id();
                     } elseif ($this->model() instanceof \Kirby\Cms\User) {
-                        $command .= ' --user ' . $this->model()->content()->uuid()?->toString() ?? $this->model()->id();
+                        $command .= ' --user ' . $uuid ?? $this->model()->id();
                     } elseif ($this->model() instanceof \Kirby\Cms\Site) {
                         $command .= ' --site'; // boolean argument
                     }
-                    $command .= ' --model '. $this->model()->content()->uuid()?->toString() ??
+                    $command .= ' --model '. $uuid ??
                         ($this->model() instanceof \Kirby\Cms\Site ? 'site://' : $this->model()->id());
 
                     $command .= ' --quiet'; // no STDOUT on frontend PHP


### PR DESCRIPTION
Workaround to solve DuplicatePageException in multilanguage setup.

After sharing https://forum.getkirby.com/t/kirby3-janitor-a-panel-button-to-run-jobs-defined-in-php/23573/16 on discord I got following work around from Ahmet Bora https://github.com/getkirby/kirby/issues/4955. It seems that it while take a small while to fix so I would suggest to implement the work around.

Tested this locally and works + solves the problem.